### PR TITLE
Add css3 to syntax definitions

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,7 @@ class CSSLint(Linter):
 
     """Provides an interface to the csslint executable."""
 
-    syntax = ('css', 'html')
+    syntax = ('css', 'css3', 'html')
     cmd = 'csslint --format=compact'
     version_args = '--version'
     version_re = r'v(?P<version>\d+\.\d+\.\d+)'


### PR DESCRIPTION
When using the CSS3 syntax plugin (https://sublime.wbond.net/packages/CSS3) with Sublime Text's builtin CSS syntax disabled the linter doesn't function.
