### PR TITLE
Add `${temp_file}` marker to `cmd`

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -2,7 +2,7 @@ from SublimeLinter.lint import Linter, util
 
 
 class CSSLint(Linter):
-    cmd = 'csslint --format=compact'
+    cmd = 'csslint --format=compact ${temp_file}'
     regex = r'''(?xi)
         ^.+:\s*   # filename
 

--- a/linter.py
+++ b/linter.py
@@ -2,7 +2,7 @@ from SublimeLinter.lint import Linter, util
 
 
 class CSSLint(Linter):
-    cmd = 'csslint --format=compact ${temp_file}'
+    cmd = 'csslint --format=compact ${args} ${temp_file}'
     regex = r'''(?xi)
         ^.+:\s*   # filename
 


### PR DESCRIPTION
Implicit adding of the `${temp_file}` by the framework has been deprecated and SublimeLinter also logs about it.